### PR TITLE
Add cli interface and some dummy commands

### DIFF
--- a/client/my_studio_addon/addon.py
+++ b/client/my_studio_addon/addon.py
@@ -84,10 +84,12 @@ class MyStudioAddon(AYONAddon, IPluginPaths, ITrayAddon):
 def cli_main():
     print("<<<< MyStudioAddon CLI >>>>")
 
+
 @cli_main.command()
 def welcome_cli():
     print("Welcome to MyStudioAddon command line interface!")
     print("This is an example of supporting command lines.")
+
 
 @cli_main.command()
 @click_wrap.option(

--- a/client/my_studio_addon/addon.py
+++ b/client/my_studio_addon/addon.py
@@ -1,5 +1,10 @@
 import os
-from ayon_core.addon import AYONAddon, IPluginPaths, ITrayAddon
+from ayon_core.addon import (
+    click_wrap,
+    AYONAddon,
+    IPluginPaths,
+    ITrayAddon
+)
 
 MY_STUDIO_ADDON_ROOT = os.path.dirname(os.path.abspath(__file__))
 ADDON_NAME = "my_studio_addon"
@@ -67,3 +72,29 @@ class MyStudioAddon(AYONAddon, IPluginPaths, ITrayAddon):
         action_show_my_dialog.triggered.connect(self.show_my_dialog)
 
         tray_menu.addMenu(menu)
+
+    # Add CLI
+    def cli(self, click_group):
+        click_group.add_command(cli_main.to_click_obj())
+
+
+@click_wrap.group(
+    MyStudioAddon.name,
+    help="MyStudio Addon related commands.")
+def cli_main():
+    print("<<<< MyStudioAddon CLI >>>>")
+
+@cli_main.command()
+def welcome_cli():
+    print("Welcome to MyStudioAddon command line interface!")
+    print("This is an example of supporting command lines.")
+
+@cli_main.command()
+@click_wrap.option(
+    "--word",
+    help="A word to be repeated.",
+    type=str,
+    required=False
+)
+def echo(word):
+    print("Echo Echo,", word, "!")


### PR DESCRIPTION
# Changelog Description
Add example CLI Interface.
Add some dummy commands: 
- `welcome-cli` : print some welcoming text.
- `echo` : it repeats the given word. user can add a word by using `--word`

usage: 
```
. /ayon_console.exe addon my_studio_addon welcome-cli
. /ayon_console.exe addon my_studio_addon echo --word helllllo
```
> [!TIP]
> This function does nothing useful other than serve as an example of how to do it.


## Testing notes:
You can use AYON in dev mode to test these functions by passing `--use-dev` to ayon launcher. 

```powershell
 ayon-launcher/tools/ayon_console.bat --use-dev addon my_studio_addon welcome-cli
 ayon-launcher/tools/ayon_console.bat --use-dev addon my_studio_addon echo --word Hi
```