### PR TITLE
Update create_package.py

### DIFF
--- a/create_package.py
+++ b/create_package.py
@@ -281,7 +281,7 @@ def zip_client_side(addon_package_dir, current_dir, log):
 
     if not ADDON_CLIENT_DIR:
         log.debug(
-            "Skipping client code zipping, This addon doesn't contain client code."
+            "Skipping client code zipping, 'package.py' doesn't specify `client_dir`."
         )
         return
     

--- a/create_package.py
+++ b/create_package.py
@@ -47,7 +47,7 @@ with open(PACKAGE_PATH, "r") as stream:
 ADDON_VERSION = package_content["version"]
 ADDON_NAME = package_content["name"]
 ADDON_TITLE = package_content["title"]
-ADDON_CLIENT_DIR = package_content["client_dir"]
+ADDON_CLIENT_DIR = package_content.get("client_dir")
 CLIENT_VERSION_CONTENT = '''# -*- coding: utf-8 -*-
 """Package declaring {0} addon version."""
 __version__ = "{1}"
@@ -207,6 +207,9 @@ def copy_frontend_content(addon_output_dir, current_dir, log, build=True):
     frontend_dist_dirpath: str = os.path.join(frontend_dirpath, "dist")
     
     if not os.path.exists(frontend_dirpath):
+        log.debug(
+            "Skipping frontend, This addon doesn't contain frontend."
+        )
         return
     
     if build:
@@ -276,12 +279,20 @@ def zip_client_side(addon_package_dir, current_dir, log):
         log (logging.Logger): Logger object.
     """
 
+    if not ADDON_CLIENT_DIR:
+        log.debug(
+            "Skipping client code zipping, This addon doesn't contain client code."
+        )
+        return
+    
     client_dir = os.path.join(current_dir, "client")
     client_addon_dir = os.path.join(client_dir, ADDON_CLIENT_DIR)
     if not os.path.isdir(client_addon_dir):
-        raise ValueError(
-            f"Failed to find client directory '{client_addon_dir}'"
+        log.debug(
+            "Skipping client code zipping, Client code path '{}' doesn't exist."
+            .format(client_addon_dir)
         )
+        return
 
     log.info("Preparing client code zip")
     private_dir = os.path.join(addon_package_dir, "private")
@@ -300,6 +311,7 @@ def zip_client_side(addon_package_dir, current_dir, log):
     
     pyproject_toml = os.path.join(client_dir, "pyproject.toml")
     if os.path.exists(pyproject_toml):
+        log.debug("'pyproject.toml' was found, Copying to packaging directory.")
         shutil.copy(pyproject_toml, private_dir)
 
 

--- a/create_package.py
+++ b/create_package.py
@@ -205,7 +205,10 @@ def copy_frontend_content(addon_output_dir, current_dir, log, build=True):
     filepaths_to_copy = []
     frontend_dirpath = os.path.join(current_dir, "frontend")
     frontend_dist_dirpath: str = os.path.join(frontend_dirpath, "dist")
-
+    
+    if not os.path.exists(frontend_dirpath):
+        return
+    
     if build:
         npm_executable = _get_executable("npm")
         if npm_executable is None:
@@ -294,8 +297,10 @@ def zip_client_side(addon_package_dir, current_dir, log):
         for path, sub_path in find_files_in_subdir(client_addon_dir):
             sub_path = os.path.join(ADDON_CLIENT_DIR, sub_path)
             zipf.write(path, sub_path)
-
-    shutil.copy(os.path.join(client_dir, "pyproject.toml"), private_dir)
+    
+    pyproject_toml = os.path.join(client_dir, "pyproject.toml")
+    if os.path.exists(pyproject_toml):
+        shutil.copy(pyproject_toml, private_dir)
 
 
 def create_server_package(


### PR DESCRIPTION
## Changelog Description
Skip few paths if they don't exist. 

## Additional info
This PR is not necessary for this example addon as `client` directory, `pyproject.toml`  and `frontend` always exist.
But, this PR becomes handy when someone is using this addon as template where they may don't need  `pyproject.toml`  and `frontend`.

> [!NOTE]
> Please feel free to suggest closing this PR  if you think it doesn't add a value.
> However, I'm using the same `create_package.py` in this branch in multiple places (locally on my side when making some trials to learn about addon creation). 