### PR TITLE
Fix no version found warning 

### DIFF
--- a/client/my_studio_addon/addon.py
+++ b/client/my_studio_addon/addon.py
@@ -6,13 +6,18 @@ from ayon_core.addon import (
     ITrayAddon
 )
 
+from .version import __version__
+
+
 MY_STUDIO_ADDON_ROOT = os.path.dirname(os.path.abspath(__file__))
 ADDON_NAME = "my_studio_addon"
 ADDON_LABEL = "My Studio Addon"
 
+
 class MyStudioAddon(AYONAddon, IPluginPaths, ITrayAddon):
     name = ADDON_NAME
     label = ADDON_LABEL
+    version = __version__
 
     def initialize(self, settings):
         """Initialization of module."""


### PR DESCRIPTION
## Changelog Description
Add version to `addon.py` which fixes this warning when launching ayon launcher.
```
DEV WARNING: Addon 'my_studio_addon' does not have defined version.
```

## Testing Notes
1. when launching ayon launcher, the warning shouldn't appear.